### PR TITLE
Fixing all errors in console that are not caused by missing dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     compile "org.spongepowered:spongeapi:$spongeVersion"
     compile 'com.flowpowered:flow-math:1.0.1'
     compile 'org.mapdb:mapdb:3.0.0-M5'
+	compile 'org.mapdb:elsa:3.0.0-M2'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 
@@ -97,8 +98,8 @@ shadowJar {
     dependencies {
         include dependency('com.flowpowered:flow-math')
         include dependency('org.mapdb:mapdb')
+		include dependency('org.mapdb:elsa')
     }
-    relocate 'com.flowpowered.math', 'net.foxdenstudio.shadow.flowmath'
     relocate 'org.mapdb', 'net.foxdenstudio.shadow.mapdb'
 }
 


### PR DESCRIPTION
Relocating the math library causes the referenced path to be wrong either in both plugins or in FG only.

To make all errors go away, you have to add the following jar files (best fetching them from the maven repository website) to the mods directory: 

- eclipse-collections-api-7.0.1.jar
- eclipse-collections-7.0.1.jar
- eclipse-collections-forkjoin.7.0.1.jar
- kotlin-runtime-1.0.1.jar
- kotlin-stdlib-1.0.1.jar
- lz4-1.3.0.jar

not tested, but likely also 'guava-19.0.jar'