### PR TITLE
Removing flowmath from the exports and fixing errors again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ repositories {
 
 dependencies {
     compile "org.spongepowered:spongeapi:$spongeVersion"
-    compile 'com.flowpowered:flow-math:1.0.1'
     compile 'org.mapdb:mapdb:3.0.0-M6'
 //	compile 'org.mapdb:elsa:3.0.0-M2'
     testCompile group: 'junit', name: 'junit', version: '4.11'
@@ -96,7 +95,6 @@ shadowJar {
     classifier = ''
     dependsOn reobfJar
     dependencies {
-        include dependency('com.flowpowered:flow-math')
         include dependency('org.mapdb:mapdb')
         include dependency('org.mapdb:elsa')
         include dependency('org.eclipse.collections:eclipse-collections')
@@ -144,7 +142,6 @@ task serverLiteJar(type: Jar) {
 task libJar(type: ShadowJar){
     classifier = 'lib'
     dependencies{
-        include dependency('com.flowpowered:flow-math')
         include dependency('org.mapdb:mapdb')
         include dependency('org.mapdb:elsa')
         include dependency('org.eclipse.collections:eclipse-collections')

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ shadowJar {
         include dependency('net.jpountz.lz4:lz4')
         include dependency('com.google.guava:guava:19.0')
     }
+    relocate 'org.mapdb', 'net.foxdenstudio.shadow.mapdb'
 }
 
 task serverJar(type: ShadowJar) {
@@ -124,6 +125,7 @@ task serverJar(type: ShadowJar) {
         exclude "net/foxdenstudio/sponge/foxcore/mod"
     }
     configurations = [project.configurations.runtime]
+    relocate 'org.mapdb', 'net.foxdenstudio.shadow.mapdb'
     exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
 }
 
@@ -153,6 +155,7 @@ task libJar(type: ShadowJar){
         include dependency('com.google.guava:guava:19.0')
     }
     configurations = [project.configurations.runtime]
+    relocate 'org.mapdb', 'net.foxdenstudio.shadow.mapdb'
     exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
 }
 
@@ -170,6 +173,7 @@ task serverLibJar(type: ShadowJar){
         include dependency('com.google.guava:guava:19.0')
     }
     configurations = [project.configurations.runtime]
+    relocate 'org.mapdb', 'net.foxdenstudio.shadow.mapdb'
     exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
 }
 


### PR DESCRIPTION
So first of all, if flowmath is provided by either forge or sponge, not sure which of the two though, there is actually no need to export it here, also this will prevent future build errors as the codebase used by the sponge and plugin code is the same.

Secondly, I have no clue why and this needs confirmation on another test system then the one I happened to test this on, but removing the remap for mapdb entirely broke the compiled kotlin files it runs on, because these for some reason I don't quite understand, tried to still refeference their own, previously relocated files. I confirmed that this also happens when using the precompiled files you provide. 

I am unable to confirm if this is bound to my test system or ocurrs across different machines, due to technical limitations (i.e. I don't have another system to run a test server on), but its strange nonetheless.